### PR TITLE
this should fix crashing of homebridge if an error occurred

### DIFF
--- a/ipmi.js
+++ b/ipmi.js
@@ -97,13 +97,18 @@ class IPMIPlugin
     // TODO: throttle refreshes? currently schedules an update for each get (even if redundant)
     const refreshdata = true; // fix/workaround https://github.com/egeback/node-ipmi/pull/1 Fix callback reuse when not refreshing
     this.server.getSensors((err, sensors) => {
-      if (err) throw err;
+      if (err) {
+          this.log("Error occurred on refresh. Try again later.");
+          return;
+      }
 
-       for (let i = 0; i < sensors.length; ++i) {
-         const sensor = sensors[i];
+      if (sensors !== null) {}
+        for (let i = 0; i < sensors.length; ++i) {
+          const sensor = sensors[i];
 
-         this.cache[sensor.data.name] = sensor.data.value;
-       }
+          this.cache[sensor.data.name] = sensor.data.value;
+        }
+      }
        //console.log('updated cache=',this.cache);
     }, refreshdata);
   }


### PR DESCRIPTION
Homebridge crashes after an error occurred on calling ipmitool.

Error: Unable to establish LAN session

    at ChildProcess.exithandler (child_process.js:273:12)
    at ChildProcess.emit (events.js:180:13)
    at maybeClose (internal/child_process.js:936:16)
    at Socket.stream.socket.on (internal/child_process.js:353:11)
    at Socket.emit (events.js:180:13)
    at Pipe._handle.close [as _onclose] (net.js:538:12)